### PR TITLE
Set lib flag

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -173,7 +173,7 @@
               mv libraries $out/libraries
 
               makeWrapper ${pkgs.jre}/bin/java $out/bin/effekt \
-                --add-flags "-jar $out/lib/effekt.jar" \
+                --add-flags "-jar $out/lib/effekt.jar --lib $out/libraries/common" \
                 --prefix PATH : ${pkgs.lib.makeBinPath (pkgs.lib.concatMap (b: b.buildInputs) backends)}
             '';
 


### PR DESCRIPTION
This PR sets the lib flag to _ensure_ that the libraries saved in the nix store are used and the path is not dynamically resolved.